### PR TITLE
Make ARCH and RCLONE_VERSION build-time arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM alpine:3.5
 
 MAINTAINER Brian J. Cardiff <bcardiff@gmail.com>
 
-ENV RCLONE_VERSION=current
-ENV ARCH=amd64
+ARG RCLONE_VERSION=current
+ARG ARCH=amd64
 ENV SYNC_SRC=
 ENV SYNC_DEST=
 ENV SYNC_OPTS=-v


### PR DESCRIPTION
This is so that you can override the variables at build time.
They are currently not used anywhere else.