### PR TITLE
Add Healthchecks.io start ping before sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ ENV CRON=
 ENV CRON_ABORT=
 ENV FORCE_SYNC=
 ENV CHECK_URL=
-ENV START_URL=
 ENV TZ=
 
 RUN apk -U add ca-certificates fuse wget dcron tzdata \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV CRON=
 ENV CRON_ABORT=
 ENV FORCE_SYNC=
 ENV CHECK_URL=
+ENV START_URL=
 ENV TZ=
 
 RUN apk -U add ca-certificates fuse wget dcron tzdata \

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A few environment variables allow you to customize the behavior of the sync:
 * `CRON_ABORT` crontab schedule `0 6 * * *` to abort sync at 6am
 * `FORCE_SYNC` set variable to perform a sync upon boot
 * `CHECK_URL` [healthchecks.io](https://healthchecks.io) url or similar cron monitoring to perform a `GET` after a successful sync
+* `START_URL` same as `CHECK_URL`, but is called before sync starts. If `CHECK_URL` is defined as a healthchecks.io URL, this defaults to [${CHECK_URL}/start](https://healthchecks.io/docs/#start-event).
 * `SYNC_OPTS` additional options for `rclone sync` command. Defaults to `-v`
 * `TZ` set the [timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) to use for the cron and log `America/Argentina/Buenos_Aires`
 

--- a/sync.sh
+++ b/sync.sh
@@ -12,10 +12,15 @@ else
 echo $$ > /tmp/sync.pid
 
 if test "$(rclone ls --max-depth 1 $SYNC_SRC $RCLONE_OPTS)"; then
-  # Send "start" ping to HC, if set 
-  if [ -n "$CHECK_URL" ]
+  # Send a start ping if a) START_URL is explicitly set OR b) if Healthchecks.io is used as CHECK_URL provider
+  if [ -z ${START_URL+x} ]
   then
-    wget "${CHECK_URL}/start" -O /dev/null
+    if echo "$CHECK_URL" | grep "hc-ping"
+    then
+      wget "${CHECK_URL}/start" -O /dev/null
+    fi
+  else
+    wget $START_URL -O /dev/null
   fi
     
   # the source directory is not empty

--- a/sync.sh
+++ b/sync.sh
@@ -13,7 +13,7 @@ echo $$ > /tmp/sync.pid
 
 if test "$(rclone ls --max-depth 1 $SYNC_SRC $RCLONE_OPTS)"; then
   # Send a start ping if a) START_URL is explicitly set OR b) if Healthchecks.io is used as CHECK_URL provider
-  if [ -z ${START_URL} ]
+  if [ -z ${START_URL+x} ]
   then
     if echo "$CHECK_URL" | grep "hc-ping"
     then

--- a/sync.sh
+++ b/sync.sh
@@ -13,7 +13,7 @@ echo $$ > /tmp/sync.pid
 
 if test "$(rclone ls --max-depth 1 $SYNC_SRC $RCLONE_OPTS)"; then
   # Send a start ping if a) START_URL is explicitly set OR b) if Healthchecks.io is used as CHECK_URL provider
-  if [ -z ${START_URL+x} ]
+  if [ -z ${START_URL} ]
   then
     if echo "$CHECK_URL" | grep "hc-ping"
     then

--- a/sync.sh
+++ b/sync.sh
@@ -17,7 +17,7 @@ if test "$(rclone ls --max-depth 1 $SYNC_SRC $RCLONE_OPTS)"; then
   then
     if echo "$CHECK_URL" | grep "hc-ping"
     then
-      wget "${CHECK_URL}/start" -O /dev/null
+      wget "$CHECK_URL/start" -O /dev/null
     fi
   else
     wget $START_URL -O /dev/null

--- a/sync.sh
+++ b/sync.sh
@@ -27,7 +27,7 @@ if test "$(rclone ls --max-depth 1 $SYNC_SRC $RCLONE_OPTS)"; then
   # it can be synced without clear data loss
   echo "INFO: Starting rclone sync $SYNC_SRC $SYNC_DEST $RCLONE_OPTS $SYNC_OPTS"
   rclone sync $SYNC_SRC $SYNC_DEST $RCLONE_OPTS $SYNC_OPTS
-  
+
   # Send "done" ping to HC, if set
   if [ -z "$CHECK_URL" ]
   then

--- a/sync.sh
+++ b/sync.sh
@@ -12,11 +12,18 @@ else
 echo $$ > /tmp/sync.pid
 
 if test "$(rclone ls --max-depth 1 $SYNC_SRC $RCLONE_OPTS)"; then
+  # Send "start" ping to HC, if set 
+  if [ -n "$CHECK_URL" ]
+  then
+    wget "${CHECK_URL}/start" -O /dev/null
+  fi
+    
   # the source directory is not empty
   # it can be synced without clear data loss
   echo "INFO: Starting rclone sync $SYNC_SRC $SYNC_DEST $RCLONE_OPTS $SYNC_OPTS"
   rclone sync $SYNC_SRC $SYNC_DEST $RCLONE_OPTS $SYNC_OPTS
-
+  
+  # Send "done" ping to HC, if set
   if [ -z "$CHECK_URL" ]
   then
     echo "INFO: Define CHECK_URL with https://healthchecks.io to monitor sync job"


### PR DESCRIPTION
Adds a [/start ping](https://healthchecks.io/docs/#start-event) to Healthchecks.io to help debug stuck jobs and measure execution time.

I've tested this both with and without  $CHECK_URL set and it worked fine. Hopefully it can be useful for someone else.

Thanks @bcardiff for the great image!
