### PR TITLE
Fixed issue where sync fails if SYNC_SRC only has directories

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -11,7 +11,7 @@ else
 
 echo $$ > /tmp/sync.pid
 
-if test "$(rclone ls --max-depth 1 $SYNC_SRC $RCLONE_OPTS)"; then
+if test "$(rclone lsf --max-depth 1 $SYNC_SRC $RCLONE_OPTS)"; then
   # the source directory is not empty
   # it can be synced without clear data loss
   echo "INFO: Starting rclone sync $SYNC_SRC $SYNC_DEST $RCLONE_OPTS $SYNC_OPTS"


### PR DESCRIPTION
I ran into an issue where I'm trying to back up my NAS and the SYNC_SRC root only has directories in it. `rclone ls` only checks for files. `rclone lsf` checks for files and directories.